### PR TITLE
Add var for specifying the source of Chocolatey itself, readme updates

### DIFF
--- a/PSTestWinibleZ.yml
+++ b/PSTestWinibleZ.yml
@@ -1,7 +1,7 @@
 name: win_chocolatey_server
-version: 0.1.0
+version: 0.2.0
 ci_platform: appveyor-windows
 ansible_versions:
-- 2.4.6.0
-- 2.5.6
-- 2.6.1
+- 2.6.17
+- 2.7.11
+- 2.8.0

--- a/README.md
+++ b/README.md
@@ -56,10 +56,22 @@ None, this role will run with the default options set.
 * `opt_chocolatey_server_https_certificate`: The certificate thumbprint to use for the HTTPS binding, if not specified then .
 * `opt_chocolatey_server_max_package_size`: The maximum allowed size, in bytes, of a package that can be stored on the server (default: `2147483648`).
 * `opt_chocolatey_server_path`: The root directory that the `chocolatey.server` package is installed to (default: `C:\tools`).
-* `opt_chocolatey_server_source`: The source location of the [chocolatey.server](https://chocolatey.org/packages/chocolatey.server) package (default: `https://chocolatey.org/api/v2/`). This can be the name/url of a Nuget repository or a local path that contains the nupkg file.
 
-To set up the Chocolatey server to create an `install.ps1` script and source
-the installer file from the repo instead of the internet, download the
+There are two variables that control the source location when sourcing
+Chocolatey itself and the `chocolatey.server` package.
+
+* `opt_chocolatey_server_chocolatey_source`: Override the `source` location for the step that installs Chocolatey itself. This value should be a URI to an `install.ps1` file. Omitting this value will mean Chocolatey will use `https://chocolatey.org/install.ps1`.
+* `opt_chocolatey_server_source`: The source location of the [chocolatey.server](https://chocolatey.org/packages/chocolatey.server) package. If this is omitted then it uses whatever source priority is set within Chocolatey itself. This can be the name/url of a Nuget repository or a local path that contains the nupkg file.
+
+If Chocolatey is already installed on that host,
+`opt_chocolatey_server_chocolatey_source` can be ignored. The script that var
+points to should contain the logic that installs the Chocolatey client itself.
+This could be an exact copy of `https://chocolatey.org/install.ps1` or a
+modified version that sources the various download artifacts from another
+offline source.
+
+To set up the Chocolatey server to create an `install.ps1` for other servers to
+use when bootstrapping Chocolatey itself. Download the
 [chocolatey nupkg](https://chocolatey.org/packages/chocolatey) file and set one
 of the following two variables that point to this file;
 
@@ -112,6 +124,21 @@ None
   - name: output the cert hash used for the HTTPS bindings
     debug:
       var: out_chocolatey_server_https_certificate
+
+- name: install Chocolatey and Chocolatey Server with an offline location
+  hosts: windows
+  gather_facts: no
+  vars:
+    # This is the location of the Chocolatey install.ps1 script, this needs to
+    # be amended manually to install Chocolatey itself in an offline fashion
+    # and is outside the scope of this role.
+    opt_chocolatey_server_chocolatey_source: \\fileshare\share\chocolatey\install.ps1
+
+    # This is the location of the chocolatey.server.npkg file
+    opt_chocolatey_server_source: \\fileshare\share\chocolatey\chocolatey.server.npkg
+
+  roles:
+  - jborean93.win_chocolatey_server
 ```
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 opt_chocolatey_server_path: C:\tools
-opt_chocolatey_server_source: https://chocolatey.org/api/v2/
 opt_chocolatey_server_max_package_size: 2147483648
 opt_chocolatey_server_http_port: 80
 opt_chocolatey_server_firewall_profiles: domain,private

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,10 +4,11 @@ galaxy_info:
   author: Jordan Borean
   description: Install Chocolatey Server on Windows role
   license: MIT
-  min_ansible_version: 2.4
+  min_ansible_version: 2.6
   platforms:
   - name: Windows
     versions:
+    - Server 2019
     - Server 2016
     - Server 2012 R2
     - Server 2012

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,11 +11,17 @@
   - machine
   - user
 
+- name: ensure Chocolatey is installed
+  win_chocolatey:
+    name: chocolatey
+    state: present
+    source: '{{ opt_chocolatey_server_chocolatey_source | default(omit) }}'
+
 - name: install the chocolatey.server package
   win_chocolatey:
     name: chocolatey.server
     state: present
-    source: '{{ opt_chocolatey_server_source }}'
+    source: '{{ opt_chocolatey_server_source | default(omit) }}'
 
 - name: get OS version
   win_file_version:
@@ -47,10 +53,9 @@
 
 - name: install IIS server features
   win_feature:
+    name: '{{ pri_chocolatey_server_features }}'
     name: '{{ item }}'
     state: present
-  # prefer to use list in name but this does not work in Ansible 2.4, change this once 2.4 is out of support
-  with_items: '{{ pri_chocolatey_server_features }}'
   register: pri_chocolatey_server_install
 
 # bug in Server 2008 R2, need to re-register ASP.NET so IIS can detect it


### PR DESCRIPTION
Expand on the documentation for installing in an offline source. Also bump the minimum versions to the latest supported by Ansible.

Fixes https://github.com/jborean93/ansible-role-win_chocolatey_server/issues/5.

This will need to wait until I've sorted out the CI issues, hopefully won't be too long until I can get back to it.